### PR TITLE
update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Publish
 .publish/
+src/test.py
 
 # Obsidian
 .obsidian/

--- a/src/main.py
+++ b/src/main.py
@@ -19,5 +19,5 @@ if __name__ == '__main__':
     findings = Findings()
     ProjectFileEditor.scan_and_delete_marked_package_references(findings)
     if len(findings.get_projects()) >=1: 
-        git_utils = PullRequestCreator(repo, findings)
+        git_utils = PullRequestCreator(repo, token,  findings)
         git_utils.create_pull_request()


### PR DESCRIPTION
### [AB#192299](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/192299)

## Aim of the PR
Change how the commit procedure is done by this github action so that the commits are signed. 

## Implementation 
I found no way to sign commits using the Github module from python. After some research I found that using the git rest api directly without stating the author of the commit would sign it if a bot committed the changes. 
Link https://192dot.medium.com/sign-commit-using-github-actions-app-13488f6e76b7 

I am not sure if this will work, so it will have to be tested once these changes is merged. 